### PR TITLE
Fix RFC3986 encoding for "%"

### DIFF
--- a/SAMtags.tex
+++ b/SAMtags.tex
@@ -328,7 +328,7 @@ optional \emph{values} are all percent encoded according to
 RFC3986 to escape meta-characters `{\tt =}', `{\tt \%}', `{\tt ;}',
 `{\tt |}' or non-printable characters not matched by the isprint()
 macro (with the C locale). For example a percent sign becomes
-`{\tt \%2C}'.
+`{\tt \%25}'.
 %NOTE - This leaves open the possibility of allowing multiple such
 %entries for a single CT tag to be combined with | as in the PT tag.
 


### PR DESCRIPTION
RFC3986 encoding for "%" is "%25" (rather than "%2C").